### PR TITLE
Fix entrypoint bootstrap for macOS and correct rosdep usage

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 
-# All setup is best-effort. The container MUST reach `exec "$@"` (sleep infinity)
-# so VS Code / Cursor can attach. No step here should be able to kill the container.
+# The container MUST reach `exec "$@"` so the IDE can attach.
+# Keep every step best-effort where possible.
 
 SENTINEL="/home/ws/.devcontainer/.setup_done"
 
+# Source ROS early so ROS_DISTRO and other vars are available for rosdep.
+source "/opt/ros/${ROS_DISTRO:-kilted}/setup.bash" 2>/dev/null || true
+
 if [ ! -f "$SENTINEL" ]; then
     echo "[entrypoint] First-run setup..."
-    sudo chown -R "$(whoami)" /home/ws                             2>&1 || true
-    sudo rm -f /home/ws/.git/*.lock /home/ws/.git/refs/heads/*.lock     || true
-    sudo rosdep update                                             2>&1 || true
-    sudo rosdep install --from-paths src --ignore-src -y           2>&1 || true
-    mkdir -p "$(dirname "$SENTINEL")" && touch "$SENTINEL"              || true
+    sudo chown -R "$(whoami)" /home/ws                                  2>&1 || true
+    sudo rm -f /home/ws/.git/*.lock /home/ws/.git/refs/heads/*.lock          || true
+    rosdep update                                                       2>&1 || true
+    sudo -E rosdep install --from-paths src --ignore-src -y             2>&1 || true
+    mkdir -p "$(dirname "$SENTINEL")" && touch "$SENTINEL"                   || true
 fi
-
-# ROS setup scripts reference uninitialized vars; source without strict mode
-source "/opt/ros/${ROS_DISTRO:-kilted}/setup.bash" 2>/dev/null || true
 
 echo "[entrypoint] Building ROS 2 workspace..."
 colcon build --symlink-install 2>&1 || echo "[entrypoint] colcon build failed (non-fatal)"


### PR DESCRIPTION
- Source ROS before rosdep so ROS_DISTRO is available during first-run
- Allow chown partial failures on macOS bind-mounts
- Run rosdep update without sudo to avoid root-owned cache
- Preserve env through sudo for rosdep install

Made-with: Cursor